### PR TITLE
Update Twilio Voice iOS to 4.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Video iOS SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget-4.6.2-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget-4.6.3-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Video.XamarinBinding
 
 ## How to Build
 
-### Twilio.Video iOS 4.6.2 (November 5, 2021)
+### Twilio.Video iOS 4.6.3 (December 10, 2021)
 ```
 sh bootstrapper.sh
 ```

--- a/src/Podfile
+++ b/src/Podfile
@@ -6,4 +6,4 @@ target 'ObjectiveSharpieIntegration' do
   use_frameworks!
 end
 
-pod 'TwilioVideo', '4.6.2'
+pod 'TwilioVideo', '4.6.3'

--- a/src/Podfile.lock
+++ b/src/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - TwilioVideo (4.6.2)
+  - TwilioVideo (4.6.3)
 
 DEPENDENCIES:
-  - TwilioVideo (= 4.6.2)
+  - TwilioVideo (= 4.6.3)
 
 SPEC REPOS:
   trunk:
     - TwilioVideo
 
 SPEC CHECKSUMS:
-  TwilioVideo: f8c75425bce3f41912bb24352154b0502d89a9b3
+  TwilioVideo: 4afaac028c5886f2f3b313a9fcc146a6b7ca34e2
 
-PODFILE CHECKSUM: 79d97c4534d6ed2fc1674c5fa79626b44afa98a6
+PODFILE CHECKSUM: 3b01c9be15bd09b4adb44835f4ddcd54c51bad9d
 
 COCOAPODS: 1.11.2

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using Foundation;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("4.6.2")]
+[assembly: AssemblyVersion("4.6.3")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/src/StructsAndEnums.cs
+++ b/src/StructsAndEnums.cs
@@ -171,6 +171,7 @@ namespace Twilio.Video.iOS
 		ParticipantAccountLimitExceededError = 53206,
 		ParticipantMaxPublishedTracksOutOfRangeError = 53207,
 		ParticipantInvalidSubscribeRuleError = 53215,
+		ParticipantSessionLengthExceededError = 53216,
 		TrackInvalidError = 53300,
 		TrackNameInvalidError = 53301,
 		TrackNameTooLongError = 53302,

--- a/src/twilio-video.nuspec
+++ b/src/twilio-video.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Twilio.Video.XamarinBinding</id>
-    <version>4.6.2.0</version>
+    <version>4.6.3.0</version>
     <authors>twilio</authors>
     <owners>twilio</owners>
     <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS</projectUrl>


### PR DESCRIPTION
This PR updates the Twilio Video iOS binding to the latest 4.6.3 version https://www.twilio.com/docs/video/changelog-twilio-video-ios-latest#463-december-10-2021

Here are the diff of StructsAndEnums between version 4.6.2 and 4.6.3. The ApiDefinitions didn't had any differences.
[StructsAndEnums-4.6.2-4.6.3.patch.txt](https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS/files/7697868/StructsAndEnums-4.6.2-4.6.3.patch.txt)
