### PR TITLE
Update Twilio Video iOS to 5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Video iOS SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget-5.0.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget-5.1.0-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Video.XamarinBinding
 
 ## How to Build
 
-### Twilio.Video iOS 5.0.0 (February 14, 2022)
+### Twilio.Video iOS 5.1.0 (March 15, 2022)
 ```
 sh bootstrapper.sh
 ```

--- a/src/ApiDefinition.cs
+++ b/src/ApiDefinition.cs
@@ -820,6 +820,14 @@ namespace Twilio.Video.iOS
 		string Name { get; }
 	}
 
+	[Static]
+	partial interface Constants
+	{
+		// extern TVIVideoEncodingMode  _Nonnull const TVIVideoEncodingModeAuto __attribute__((availability(ios, introduced=11.0)));
+		[Field ("TVIVideoEncodingModeAuto", "__Internal")]
+		NSString TVIVideoEncodingModeAuto { get; }
+	}
+
 	// @interface TVIConnectOptionsBuilder : NSObject
 	[BaseType (typeof(NSObject))]
 	[DisableDefaultCtor]
@@ -884,6 +892,10 @@ namespace Twilio.Video.iOS
 		// @property (copy, nonatomic) NSString * _Nullable roomName;
 		[NullAllowed, Export ("roomName")]
 		string RoomName { get; set; }
+
+		// @property (copy, nonatomic) TVIVideoEncodingMode _Nullable videoEncodingMode;
+		[NullAllowed, Export ("videoEncodingMode")]
+		string VideoEncodingMode { get; set; }
 
 		// @property (copy, nonatomic) NSArray<TVILocalVideoTrack *> * _Nonnull videoTracks;
 		[Export ("videoTracks", ArgumentSemantic.Copy)]
@@ -978,6 +990,10 @@ namespace Twilio.Video.iOS
 		// @property (readonly, copy, nonatomic) NSString * _Nullable roomName;
 		[NullAllowed, Export ("roomName")]
 		string RoomName { get; }
+
+		// @property (readonly, copy, nonatomic) TVIVideoEncodingMode _Nullable videoEncodingMode;
+		[NullAllowed, Export ("videoEncodingMode")]
+		string VideoEncodingMode { get; }
 
 		// @property (readonly, copy, nonatomic) NSArray<TVILocalVideoTrack *> * _Nonnull videoTracks;
 		[Export ("videoTracks", ArgumentSemantic.Copy)]

--- a/src/Podfile
+++ b/src/Podfile
@@ -6,4 +6,4 @@ target 'ObjectiveSharpieIntegration' do
   use_frameworks!
 end
 
-pod 'TwilioVideo', '5.0.0'
+pod 'TwilioVideo', '5.1.0'

--- a/src/Podfile.lock
+++ b/src/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - TwilioVideo (5.0.0)
+  - TwilioVideo (5.1.0)
 
 DEPENDENCIES:
-  - TwilioVideo (= 5.0.0)
+  - TwilioVideo (= 5.1.0)
 
 SPEC REPOS:
   trunk:
     - TwilioVideo
 
 SPEC CHECKSUMS:
-  TwilioVideo: 9df407eeec08ddd41fcd8dbbee9b2775ea25c2d2
+  TwilioVideo: 6c5322304f5705b6ebb6cbdc22c42148cb93ee1d
 
-PODFILE CHECKSUM: 139a7bf65a265fd5b28e4370f9ad157a5a64c546
+PODFILE CHECKSUM: c9a7dfec60fac6bb3f71754c1db4aa7fe2fa0baf
 
 COCOAPODS: 1.11.2

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using Foundation;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("5.0.0")]
+[assembly: AssemblyVersion("5.1.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/src/twilio-video.nuspec
+++ b/src/twilio-video.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Twilio.Video.XamarinBinding</id>
-    <version>5.0.0.0</version>
+    <version>5.1.0.0</version>
     <authors>twilio</authors>
     <owners>twilio</owners>
     <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS</projectUrl>


### PR DESCRIPTION
This one updated the Twilio Video iOS binding to the latest 5.0.0 version
https://github.com/twilio/twilio-video-ios/releases/tag/5.1.0
https://www.twilio.com/docs/video/changelog-twilio-video-ios-latest#510-march-14-2022

Here are the diff's of ApiDefinitions and StructsAndEnums between version 5.0.0 and 5.1.0.
[ApiDefinitions-5.0.0-5.1.0.patch.txt](https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS/files/8256011/ApiDefinitions-5.0.0-5.1.0.patch.txt)

Here are the ApiDefinitions and StructsAndEnums of version 5.0.0.
[ApiDefinitions-5.0.0.cs.txt](https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS/files/8062183/ApiDefinitions-5.0.0.cs.txt)
[StructsAndEnums-5.0.0.cs.txt](https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS/files/8062184/StructsAndEnums-5.0.0.cs.txt)

Here are the ApiDefinitions and StructsAndEnums of version 5.1.0.
[ApiDefinitions-5.1.0.cs.txt](https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS/files/8256022/ApiDefinitions-5.1.0.cs.txt)
[StructsAndEnums-5.1.0.cs.txt](https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS/files/8256023/StructsAndEnums-5.1.0.cs.txt)
