### PR TITLE
Update Twilio Video iOS to 5.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ Twilio Video iOS SDK binding for Xamarin
 
 [![NuGet][nuget-img]][nuget-link]
 
-[nuget-img]: https://img.shields.io/badge/nuget-5.1.0-blue.svg
+[nuget-img]: https://img.shields.io/badge/nuget-5.1.1-blue.svg
 [nuget-link]: https://www.nuget.org/packages/Twilio.Video.XamarinBinding
 
 ## How to Build
 
-### Twilio.Video iOS 5.1.0 (March 15, 2022)
+### Twilio.Video iOS 5.1.1 (July 5, 2022)
 ```
 sh bootstrapper.sh
 ```
@@ -23,7 +23,7 @@ Sometimes adding -cxx is also required.
 
 [delegate sample](sample)
 
-[voice-quickstart-swift](https://github.com/twilio/video-quickstart-ios)
+[video-quickstart-swift](https://github.com/twilio/video-quickstart-ios)
 
 ## Contributions
 

--- a/src/Podfile
+++ b/src/Podfile
@@ -6,4 +6,4 @@ target 'ObjectiveSharpieIntegration' do
   use_frameworks!
 end
 
-pod 'TwilioVideo', '5.1.0'
+pod 'TwilioVideo', '5.1.1'

--- a/src/Podfile.lock
+++ b/src/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - TwilioVideo (5.1.0)
+  - TwilioVideo (5.1.1)
 
 DEPENDENCIES:
-  - TwilioVideo (= 5.1.0)
+  - TwilioVideo (= 5.1.1)
 
 SPEC REPOS:
   trunk:
     - TwilioVideo
 
 SPEC CHECKSUMS:
-  TwilioVideo: 6c5322304f5705b6ebb6cbdc22c42148cb93ee1d
+  TwilioVideo: 56aa8ca29205fff9ba69e167f818febd2d41ff95
 
-PODFILE CHECKSUM: c9a7dfec60fac6bb3f71754c1db4aa7fe2fa0baf
+PODFILE CHECKSUM: 6ba46108fc7b19acff1189b0e907d23a2aae4d4c
 
-COCOAPODS: 1.11.2
+COCOAPODS: 1.11.3

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -23,7 +23,7 @@ using Foundation;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("5.1.0")]
+[assembly: AssemblyVersion("5.1.1")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/src/twilio-video.nuspec
+++ b/src/twilio-video.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>Twilio.Video.XamarinBinding</id>
-    <version>5.1.0.0</version>
+    <version>5.1.1.0</version>
     <authors>twilio</authors>
     <owners>twilio</owners>
     <projectUrl>https://github.com/xamarin-bindings-for-twilio/TwilioVideoXamarinIOS</projectUrl>


### PR DESCRIPTION
This one updated the Twilio Video iOS binding to the latest 5.1.1 version
https://github.com/twilio/twilio-video-ios/releases/tag/5.1.1
https://www.twilio.com/docs/video/changelog-twilio-video-ios-latest#511-july-5-2022

The public API didn't change.
